### PR TITLE
Fix : Recovery of "France" in "Geo\Pays"

### DIFF
--- a/src/main/resources/request/geography/getGeoFeatures.ftlh
+++ b/src/main/resources/request/geography/getGeoFeatures.ftlh
@@ -37,7 +37,15 @@ FROM <${GEO_SIMS_GRAPH}>
 			?uri a 	igeo:TerritoireFrancais .
 			BIND("Territoire Français" AS ?typeTerritory)
 
-	}	
+	}
+		UNION
+	
+	{
+			?uri rdfs:label ?labelLg1 .
+			?uri a 	igeo:Pays .
+			BIND("pays" AS ?typeTerritory)
+
+	}		
 			
 			
 			BIND(REPLACE( STR(?uri) , '(.*/)(\\w.*$)', '$2' ) AS ?id)


### PR DESCRIPTION
Fix to respect the updated ontology "GEO" : "France" is now a "Country" and not a "FrenchTerritory" anymore.