### PR TITLE
Refactor patch distribution

### DIFF
--- a/src/main/java/fr/insee/rmes/bauhaus_services/distribution/DistributionServiceImpl.java
+++ b/src/main/java/fr/insee/rmes/bauhaus_services/distribution/DistributionServiceImpl.java
@@ -25,6 +25,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.Set;
 
+import static fr.insee.rmes.exceptions.ErrorCodes.DISTRIUBTION_INCORRECT_BODY;
+
 
 @Service
 public class DistributionServiceImpl extends RdfService implements DistributionService {
@@ -167,7 +169,7 @@ public class DistributionServiceImpl extends RdfService implements DistributionS
         String distributionByID = getDistributionByID(distributionId);
         Distribution distribution = Deserializer.deserializeBody(distributionByID, Distribution.class);
         if  (patchDistribution.getUpdated() == null && patchDistribution.getByteSize() == null && patchDistribution.getUrl() == null){
-            throw new RmesBadRequestException("One of these attributes is required : updated, byteSize or url");
+            throw new RmesBadRequestException(DISTRIUBTION_INCORRECT_BODY,"One of these attributes is required : updated, byteSize or url");
         }
         if (patchDistribution.getUpdated() != null){
             distribution.setUpdated(patchDistribution.getUpdated());

--- a/src/main/java/fr/insee/rmes/bauhaus_services/structures/utils/StructureUtils.java
+++ b/src/main/java/fr/insee/rmes/bauhaus_services/structures/utils/StructureUtils.java
@@ -376,7 +376,7 @@ public class StructureUtils extends RdfService {
     public void deleteStructure(String structureId) throws RmesException {
         String structureState = getValidationStatus(structureId);
         if(!structureState.equalsIgnoreCase("Unpublished")){
-            throw new RmesUnauthorizedException(ErrorCodes.STRUCTURE_DELETE_ONLY_UNPUBLISHED, "Only unpublished codelist can be deleted");
+            throw new RmesBadRequestException(ErrorCodes.STRUCTURE_DELETE_ONLY_UNPUBLISHED, "Only unpublished codelist can be deleted");
         }
         else {
             IRI structureIri = RdfUtils.structureIRI(structureId);

--- a/src/main/java/fr/insee/rmes/exceptions/ErrorCodes.java
+++ b/src/main/java/fr/insee/rmes/exceptions/ErrorCodes.java
@@ -78,7 +78,7 @@ public class ErrorCodes {
 	// CLASSIFICATIONS
 	public static final int CLASSIFICATION_VALIDATION_RIGHTS_DENIED = 1103 ;
 
-
+	// CODES LISTES
 	public static final int CODE_LIST_UNICITY = 1101;
 	public static final int CODE_LIST_AT_LEAST_ONE_CODE = 1102;
 	public static final int CODE_LIST_DELETE_ONLY_UNPUBLISHED = 1103;
@@ -128,6 +128,8 @@ public class ErrorCodes {
 	public static final int CLASSIFICATION_UNKNOWN_ID = 1141;
 	public static final int CLASSIFICATION_INCORRECT_BODY = 1142;
 
+	//DISTRIBUTION
+	public static final int DISTRIUBTION_INCORRECT_BODY = 1201;
 
 
 	/*

--- a/src/test/java/fr/insee/rmes/bauhaus_services/distribution/DistributionServiceImplTest.java
+++ b/src/test/java/fr/insee/rmes/bauhaus_services/distribution/DistributionServiceImplTest.java
@@ -305,9 +305,8 @@ class DistributionServiceImplTest {
     void getDistributionByID_shouldReturn404IfInexistentId() throws RmesException {
         JSONObject mockJSON = new JSONObject(EMPTY_JSON_OBJECT);
         when(repositoryGestion.getResponseAsObject(Mockito.anyString())).thenReturn(mockJSON);
-
-        assertThatThrownBy(() -> distributionService.getDistributionByID("1")).isInstanceOf(RmesNotFoundException.class)
-                .matches(rmesException -> ((RmesNotFoundException) rmesException).getStatus() == 404);
+        RmesException exception = assertThrows(RmesNotFoundException.class, () -> distributionService.getDistributionByID("1"));
+        Assertions.assertEquals("{\"details\":\"Not found\",\"message\":\"This distribution does not exist\"}", exception.getDetails());
     }
 
 
@@ -316,8 +315,8 @@ class DistributionServiceImplTest {
         PatchDistribution patch = new PatchDistribution();
         JSONObject getDistrib = new JSONObject(DISTRIB_A_PATCHER);
         when(repositoryGestion.getResponseAsObject(Mockito.anyString())).thenReturn(getDistrib);
-        assertThatThrownBy(() -> distributionService.patchDistribution("d1004", patch)).isInstanceOf(RmesBadRequestException.class)
-                .matches(rmesException -> ((RmesBadRequestException) rmesException).getStatus() == 400);
+        RmesException exception = assertThrows(RmesBadRequestException.class, () ->distributionService.patchDistribution("d1004", patch));
+        Assertions.assertEquals("{\"code\":1201,\"message\":\"One of these attributes is required : updated, byteSize or url\"}", exception.getDetails());
     }
 
     @Test

--- a/src/test/java/fr/insee/rmes/bauhaus_services/structures/utils/StructureUtilsTest.java
+++ b/src/test/java/fr/insee/rmes/bauhaus_services/structures/utils/StructureUtilsTest.java
@@ -1,0 +1,55 @@
+package fr.insee.rmes.bauhaus_services.structures.utils;
+
+
+import fr.insee.rmes.bauhaus_services.rdf_utils.RepositoryGestion;
+import fr.insee.rmes.config.Config;
+import fr.insee.rmes.exceptions.RmesBadRequestException;
+import fr.insee.rmes.exceptions.RmesException;
+import fr.insee.rmes.model.geography.GeoFeature;
+import fr.insee.rmes.model.structures.Structure;
+import fr.insee.rmes.persistance.sparql_queries.GenericQueries;
+import fr.insee.rmes.persistance.sparql_queries.structures.StructureQueries;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest(properties = { "fr.insee.rmes.bauhaus.lg1=fr", "fr.insee.rmes.bauhaus.lg2=en"})
+class StructureUtilsTest {
+    @InjectMocks
+    StructureUtils structureUtils = new StructureUtils();
+    @Mock
+    StructureUtils mockStructureUtils;
+    @MockBean
+    RepositoryGestion repositoryGestion;
+    @Autowired
+    Config config;
+
+
+    public static final String VALIDATION_STATUS = "{\"state\":\"Published\"}";
+
+
+    @Test
+    void shouldReturnBadRequestExceptionIfPublishedStructure() throws RmesException {
+        JSONObject mockJSON = new JSONObject(VALIDATION_STATUS);
+        StructureQueries.setConfig(config);
+        Structure structure = new Structure();
+        structure.setId("id");
+        when(repositoryGestion.getResponseAsObject(Mockito.anyString())).thenReturn(mockJSON);
+        RmesException exception = assertThrows(RmesBadRequestException.class, () -> structureUtils.deleteStructure("id"));
+        Assertions.assertEquals("{\"code\":1103,\"message\":\"Only unpublished codelist can be deleted\"}", exception.getDetails());
+    }
+
+}


### PR DESCRIPTION
to do as well as the other cases of RmesBadRequestExceptions
- add a "code métier" on the return
- add a control of the message in the test