### PR TITLE
fix deadlock in acceptance environements 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>fr.insee.rmes</groupId>
     <artifactId>Bauhaus-BO</artifactId>
     <packaging>jar</packaging>
-    <version>3.26.2</version>
+    <version>3.26.4</version>
     <name>Bauhaus-Back-Office</name>
     <description>Back-office services for Bauhaus</description>
     <url>https://github.com/InseeFr/Bauhaus-Back-Office</url>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,7 @@ spring.servlet.multipart.max-request-size=40MB
 
 fr.insee.rmes.bauhaus.version=@project.version@
 
-spring.threads.virtual.enabled=true
+spring.threads.virtual.enabled=false
 
 springdoc.swagger-ui.path=/index.html
 server.servlet.contextPath=/api/


### PR DESCRIPTION
solve deadlocks of apps disabling virtual threads :

- Virtual threads are not supported by apache http components 4.4.16 (https://issues.apache.org/jira/browse/HTTPCORE-746) which is brought by rdf4j
- other workaround possible : -Djdk.virtualThreadScheduler.parallelism=20 (instead of default value of 1)